### PR TITLE
Support for airsim cmdl argument

### DIFF
--- a/Config/AirSim/settings.json
+++ b/Config/AirSim/settings.json
@@ -1,0 +1,19 @@
+{
+  "SettingsVersion": 1.2,
+  "SimMode": "Multirotor",
+  "Vehicles": {
+    "Drone1": {
+      "VehicleType": "SimpleFlight",
+      "X": 4,
+      "Y": 0,
+      "Z": -2,
+      "Yaw": -180
+    },
+    "Drone2": {
+      "VehicleType": "SimpleFlight",
+      "X": 8,
+      "Y": 0,
+      "Z": -2
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ First time setup:
 pip install msgpack-rpc-python
 ```
 
-Create or modify `~/Documents/AirSim/settings.json` to configure simulation:
+Modify `$SIMBOTIC_ROOT/Config/AirSim/settings.json` to configure the simulation. By default it looks like the following:
 ```
 {
   "SettingsVersion": 1.2,
@@ -88,17 +88,13 @@ Create or modify `~/Documents/AirSim/settings.json` to configure simulation:
   }
 }
 ```
-
 ### Settings.json
-Set a different `settings.json` location path by setting *SIMBOTIC_AIRSIM_SETTINGS* environment variable:
+Set a different `settings.json` location path by changing the `SIMBOTIC_SETTINGS_PATH` variable inside the `run.sh` file.  
+
+Or by setting *SIMBOTIC_AIRSIM_SETTINGS* environment variable:
 ```
 export SIMBOTIC_AIRSIM_SETTINGS=/path/to/settings_file
 ```
-Or by providing it when running the simulation:
-```
-./run.sh /path/to/settings_file
-```
-Example: `./run.sh /home/projects/airsim_configs`  
 
 For more info visit [AirSim Settings](https://github.com/Microsoft/AirSim/blob/master/docs/settings.md)
 
@@ -107,7 +103,7 @@ Run script:
 
 ```
 cd $SIMBOTIC_ROOT/Scripts/Python
-python python multiagent.py
+python3 multiagent.py
 ```
 
 For more info visit [AirSim APIs](https://github.com/Microsoft/AirSim/blob/master/docs/apis.md)

--- a/README.md
+++ b/README.md
@@ -91,11 +91,6 @@ Modify `$SIMBOTIC_ROOT/Config/AirSim/settings.json` to configure the simulation.
 ### Settings.json
 Set a different `settings.json` location path by changing the `SIMBOTIC_SETTINGS_PATH` variable inside the `run.sh` file.  
 
-Or by setting *SIMBOTIC_AIRSIM_SETTINGS* environment variable:
-```
-export SIMBOTIC_AIRSIM_SETTINGS=/path/to/settings_file
-```
-
 For more info visit [AirSim Settings](https://github.com/Microsoft/AirSim/blob/master/docs/settings.md)
 
 Run Simbotic and hit Play in Editor, then

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Create or modify `~/Documents/AirSim/settings.json` to configure simulation:
   }
 }
 ```
+
+### Settings.json
+Set a different `settings.json` location path by setting *SIMBOTIC_AIRSIM_SETTINGS* environment variable:
+```
+export SIMBOTIC_AIRSIM_SETTINGS=/path/to/settings_file
+```
+Or by providing it when running the simulation:
+```
+./run.sh /path/to/settings_file
+```
+Example: `./run.sh /home/projects/airsim_configs`  
+
 For more info visit [AirSim Settings](https://github.com/Microsoft/AirSim/blob/master/docs/settings.md)
 
 Run Simbotic and hit Play in Editor, then

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-"$SIMBOTIC_UE4"/Engine/Binaries/Linux/UE4Editor "$SIMBOTIC_ROOT"/Simbotic.uproject
+SIMBOTIC_SETTINGS_PATH=$1
+
+"$SIMBOTIC_UE4"/Engine/Binaries/Linux/UE4Editor "$SIMBOTIC_ROOT"/Simbotic.uproject --airsim "$SIMBOTIC_SETTINGS_PATH"

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
-SIMBOTIC_SETTINGS_PATH=$1
+
+# Location of the AirSim settings.json
+SIMBOTIC_SETTINGS_PATH="$SIMBOTIC_ROOT"/Config/AirSim
 
 "$SIMBOTIC_UE4"/Engine/Binaries/Linux/UE4Editor "$SIMBOTIC_ROOT"/Simbotic.uproject --airsim "$SIMBOTIC_SETTINGS_PATH"


### PR DESCRIPTION
- Modified 'run.sh' to take the 'airsim' command line argument. Path to a default settings.json: `$SIMBOTIC_ROOT/Config/AirSim/settings.json`.
- Updated README to detail how to specify a different directory location for AirSim settings.json.